### PR TITLE
Changing Arduino_101 paths to zephyr

### DIFF
--- a/targets/zephyr/Makefile
+++ b/targets/zephyr/Makefile
@@ -21,7 +21,7 @@ endif
  
 # For testing without real hardware use qemu_x86 instead of arduino_101
 BOARD ?= arduino_101
- 
+
 O ?= $(PROJECT_BASE)/outdir
 
 ZEPHYR    ?= $(ZEPHYR_BASE)
@@ -31,7 +31,8 @@ JERRYHEAP ?= 16
 ZEPHYRINC   = $(ZEPHYR_BASE)/include
 ZEPHYRLIB   = $(ZEPHYR_BASE)/lib
 
-SOURCE_DIR = ./targets/arduino_101/src
+TARGET_ZEPHYR ?= ./targets/zephyr
+SOURCE_DIR = $(TARGET_ZEPHYR)/src
 
 export JERRY_INCLUDE = $(CURDIR)/jerry-core/
 

--- a/targets/zephyr/Makefile.zephyr
+++ b/targets/zephyr/Makefile.zephyr
@@ -29,6 +29,9 @@ ifeq ($(BOARD),qemu_x86)
 BOARD_NAME ?= qemu_x86
 endif
 
+TARGET_ZEPHYR ?= ./targets/zephyr
+SOURCE_DIR = $(TARGET_ZEPHYR)/src
+
 TYPE  ?= release
 JERRYHEAP ?= 16
 
@@ -102,10 +105,7 @@ ZEPHYR_BIN = $(OUTPUT)/zephyr/zephyr.strip
 PREFIX = $(TYPE)$(VARIETY)
 LIBS = $(TYPE).external$(VARIETY)-entry $(PREFIX).jerry-core $(PREFIX).jerry-libm.lib
 
-# TODO @sergioamr Change how we link the library to USER_LDFLAGS
-# https://gerrit.zephyrproject.org/r/#/c/2048/
-
-BUILD_CONFIG = O="$(OUTPUT)/zephyr" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_DIR="-L $(CURDIR)/$(OUTPUT)"
+BUILD_CONFIG = O="$(OUTPUT)/zephyr" V=$(V) USER_LIBS="$(LIBS)" USER_LIB_INCLUDE_DIR="-L $(CURDIR)/$(OUTPUT)" TARGET_ZEPHYR=$(TARGET_ZEPHYR)
 
 .PHONY: all
 all: jerry zephyr
@@ -129,7 +129,7 @@ endif
 	 -DEXTERNAL_CMAKE_SYSTEM_PROCESSOR=lakemont \
 	 -DEXTERNAL_LIBC_INTERFACE="$(ZEPHYR_LIBC_INC)" \
 	 -DCMAKE_TOOLCHAIN_FILE=build/configs/toolchain_external.cmake \
-	 -DEXTERNAL_BUILD_ENTRY_FILE=./targets/arduino_101/src/jerry-entry.c
+	 -DEXTERNAL_BUILD_ENTRY_FILE=$(SOURCE_DIR)/jerry-entry.c
 
 	make -C $(INTERM) $(TYPE).external$(VARIETY) V=1
 	cp `cat $(INTERM)/$(TYPE).external$(VARIETY)/list` $(OUTPUT)/.
@@ -139,7 +139,7 @@ $(ZEPHYR_BIN):
 ifdef V
 	@echo "- ZEPHYR -------------------------------------------------------"
 endif
-	make -f ./targets/arduino_101/Makefile $(BUILD_CONFIG)
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG)
 	@echo "Finished"
 	@file $(OUTPUT)/zephyr/zephyr.strip
 	@size $(OUTPUT)/zephyr/zephyr.strip	
@@ -151,10 +151,10 @@ zephyr:	$(EXTERNAL_LIB) $(ZEPHYR_BIN)
 	@touch $(ZEPHYR_BIN)
 
 qemu:	$(EXTERNAL_LIB) $(ZEPHYR_BIN)
-	make -f ./targets/arduino_101/Makefile $(BUILD_CONFIG) qemu
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) qemu
 
 flash:	$(EXTERNAL_LIB) $(OUTPUT)/zephyr/zephyr.strip
-	make -f ./targets/arduino_101/Makefile $(BUILD_CONFIG) flash
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) flash
 
 usage:
 help:
@@ -176,7 +176,7 @@ showconfig:
 	@echo "LIBS             = $(LIBS) "	
 	@echo "LIB_INCLUDE_DIR  = $(LIB_INCLUDE_DIR) "
 	@echo "BUILD_CONFIG     = $(BUILD_CONFIG) "
-	make -f ./targets/arduino_101/Makefile $(BUILD_CONFIG) showconfig
+	make -f $(TARGET_ZEPHYR)/Makefile $(BUILD_CONFIG) showconfig
 
 # TODO @sergioamr Temporal cleanup before finding why Zephyr is ignoring my 
 # 		  outdir for the project
@@ -184,11 +184,12 @@ clean:
 	@echo "Clearing Jerryscript"
 	@rm -rf $(OUTPUT)
 	@rm -rf $(INTERM)
-	@rm -f ./targets/arduino_101/src/.*.o.cmd
-	@rm -f ./targets/arduino_101/src/*.o
+	@rm -f $(SOURCE_DIR)/.*.o.cmd
+	@rm -f $(SOURCE_DIR)/*.o
 	@echo "Clearing Zephyr"
-	make -f ./targets/arduino_101/Makefile clean
-	make -f ./targets/arduino_101/Makefile pristine
+	make -f $(TARGET_ZEPHYR)/Makefile clean
+	make -f $(TARGET_ZEPHYR)/Makefile pristine
 
 mrproper:
-	make -f ./targets/arduino_101/Makefile mrproper
+	make -f $(TARGET_ZEPHYR)/Makefile mrproper
+


### PR DESCRIPTION
- Removing a todo that was done
- Changing the paths to something more generic and adaptable
- Making sure it compiles and runs

JerryScript-DCO-1.0-Signed-off-by: Sergio Martinez sergio.martinez.rodriguez@intel.com